### PR TITLE
[기능 추가] Boards 모델 추가, BoardDetailView 생성

### DIFF
--- a/boards/admin.py
+++ b/boards/admin.py
@@ -1,3 +1,21 @@
 from django.contrib import admin
+from .models import Board
 
-# Register your models here.
+
+@admin.register(Board)
+class BoardAdmin(admin.ModelAdmin):
+    list_display = (
+        "content_id",
+        "owner",
+        "title",
+        "feed_type",
+    )
+
+    list_display_links = (
+        "content_id",
+        "owner",
+        "title",
+        "feed_type",
+    )
+    
+    search_fields = ("title", "feed_type", "user__username")

--- a/boards/models.py
+++ b/boards/models.py
@@ -11,17 +11,31 @@ class Board(CommonModel):
         INSTAGRAM = "instagram", "Instagram"
         THREADS = "threads", "Threads"
 
+    content_id = models.AutoField(
+        primary_key=True,
+        editable=False,
+    )
+
+    owner = models.ForeignKey(
+        "users.User",
+        on_delete=models.CASCADE,
+        related_name="boards",
+        blank=False,
+    )
+
     title = models.CharField(
         max_length=80,
         blank=False,
         null=False,
     )
+
     feed_type = models.CharField(
         max_length=30,
         choices=FeedChoices.choices,
         blank=False,
         null=False,
     )
+
     content = models.TextField(
         max_length=500,
         blank=True,
@@ -30,8 +44,8 @@ class Board(CommonModel):
 
     hashtags = models.TextField(
         max_length=500,
-        blank=True,
-        null=True,
+        blank=False,
+        null=False,
     )
 
     viewcounts = models.PositiveIntegerField(default=0)

--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+from .models import Board
+
+
+class BoardSerializer(serializers.ModelSerializer):
+    owner = serializers.StringRelatedField(read_only=True)
+
+    class Meta:
+        model = Board
+        # fields = "__all__"
+        fields = (
+            "content_id",
+            "owner",
+            "title",
+            "feed_type",
+            "content",
+            "hashtags",
+            "viewcounts",
+            "likecounts",
+            "sharecounts",
+            "created_at",
+            "updated_at",
+        )

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    # path("new/", views.BoardNewContentView.as_view(), name="board_new_content"),
+    path("detail/<int:content_id>/", views.BoardDetailView.as_view(), name="board_detail"),
+]

--- a/boards/views.py
+++ b/boards/views.py
@@ -1,3 +1,55 @@
 from django.shortcuts import render
+from django.contrib.auth import get_user_model
 
-# Create your views here.
+from rest_framework import status
+from rest_framework import permissions
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.exceptions import NotFound, PermissionDenied
+
+from .models import Board
+from .serializers import BoardSerializer
+
+
+class BoardDetailView(APIView):
+    # board 상세 조회 view
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_object(self, content_id):
+        try:
+            return Board.objects.get(content_id=content_id)
+        except Board.DoesNotExist:
+            raise NotFound("해당 게시물을 찾을 수 없습니다.")
+
+    def get(self, request, content_id):
+        board = self.get_object(content_id)
+        serializer = BoardSerializer(board)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def put(self, request, content_id):
+        board = self.get_object(content_id)
+
+        if board.owner.id != request.user.id:
+            raise PermissionDenied("해당 게시물의 작성자가 아닙니다.")
+
+        serializer = BoardSerializer(
+            board,
+            data=request.data,
+            partial=True,
+        )
+
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        else:
+            raise NotFound("해당 게시물을 찾을 수 없습니다.")
+
+    def delete(self, request, content_id):
+        board = self.get_object(content_id)
+
+        if board.owner.id != request.user.id:
+            raise PermissionDenied("해당 게시물의 작성자가 아닙니다.")
+
+        board.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## 반영 브랜치
suhyun -> develop

---
## 변경 사항
1. Board model의 pk 필드를 content_id 로 설정
2. owner 필드 추가(user 상속)
3. BoardSerializer 생성
4. BoardDetailView 생성

---
## 테스트 결과
http://127.0.0.1:8000/api/v1/boards/detail/<int:content_id>/ 
(로그인이 되어있을 경우로 진행하였습니다.)

**admin 계정을 생성 후 로그인 진행**

```py
# GET
/api/v1/boards/detail/1/

HTTP 200 OK
{
    "content_id": 1,
    "owner": "admin",
    "title": "admin 제목",
    "feed_type": "instagram",
    "content": "admin 내용 수정",
    "hashtags": "인스타그램, 안녕, 그래",
    "viewcounts": 0,
    "likecounts": 0,
    "sharecounts": 0,
    "created_at": "2023-10-25T18:42:08.095367",
    "updated_at": "2023-10-25T18:56:57.290315"
}

PUT
{
    "content_id": 1,
    "owner": "admin",
    "title": "admin 제목",
    "feed_type": "twitter", # 수정됨
    "content": "admin twitter 수정", # 수정됨
    "hashtags": "인스타그램, 안녕, 그래",
    "viewcounts": 0,
    "likecounts": 0,
    "sharecounts": 0,
    "created_at": "2023-10-25T18:42:08.095367",
    "updated_at": "2023-10-25T19:04:46.273466"
}

DELETE
HTTP 204 No Content

다시 조회 시

HTTP 404 Not Found
{
    "detail": "해당 게시물을 찾을 수 없습니다."
}
```

본인의 게시글이 아닌 경우
```py
# GET
/api/v1/boards/detail/2/
{
    "content_id": 2,
    "owner": "test",
    "title": "test 제목",
    "feed_type": "threads",
    "content": "test",
    "hashtags": "test",
    "viewcounts": 0,
    "likecounts": 0,
    "sharecounts": 0,
    "created_at": "2023-10-25T18:51:52.722022",
    "updated_at": "2023-10-25T18:51:52.722084"
}

# PUT & Delete
HTTP 403 Forbidden
{
    "detail": "해당 게시물의 작성자가 아닙니다."
}
```
---

게시글 번호(content_id)로 조회(get)는 가능하지만, 본인의 게시글이 아니라면 수정(put),삭제(delete)는 불가합니다.
viewcounts, likecounts, sharecounts 는 아직 구현 전입니다.