### PR TITLE
[기능 수정] 게시글 목록 조회 hashtag, content 관련 오류 수정 및 Board hashtags 제약조건 수정

### DIFF
--- a/boards/models.py
+++ b/boards/models.py
@@ -54,6 +54,7 @@ class Board(CommonModel):
     hashtags = models.ManyToManyField(
         Hashtag,
         related_name='tagging',
+        blank=True,
     )
 
     # likes = models.BooleanField(default=False)

--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -59,7 +59,8 @@ class BoardListSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         # content 최대 20자 까지만 표현
         res = super().to_representation(instance)
-        res.update({'content': res['content'][:20]})
+        if res and len(res["content"]) > 20:
+            res.update({'content': res['content'][:20]})
         return res
 
       

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
-from .views import BoardShareAPIView, BoardsListAPIView, BoardDetailView, AnalyticsView, BoardWriteView, BoardLikesView
+from .views import BoardShareAPIView, BoardListAPIView, BoardDetailView, AnalyticsView, BoardWriteView, BoardLikesView
 
 
 urlpatterns = [
-    path("", BoardsListAPIView.as_view(), name="boards-list"), # 게시글 목록 조회 API
+    path("", BoardListAPIView.as_view(), name="boards-list"), # 게시글 목록 조회 API
     path("write/", BoardWriteView.as_view(), name="board-write"), # 게시글 작성 API
     path("<int:content_id>/", BoardDetailView.as_view(), name="board-detail"), # 게시글 상세 조회 API
     path("<str:feed_type>/likes/<int:content_id>/", BoardLikesView.as_view(), name="board-likes"), # 게시글 작성 API

--- a/boards/views.py
+++ b/boards/views.py
@@ -48,13 +48,13 @@ class BoardWriteView(APIView):
 
 
 # api/v1/boards/?query_params
-class BoardsListAPIView(APIView):
+class BoardListAPIView(APIView):
     """
     Assignee : 기연
     
     게시글 목록 조회 및 검색 기능
     """
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.AllowAny]
 
     query_hashtag = openapi.Parameter(
         "hashtag", openapi.IN_QUERY, type=openapi.TYPE_STRING, description="검색할 해시태그"
@@ -99,10 +99,14 @@ class BoardsListAPIView(APIView):
         search = request.query_params.get('search', '') # 검색 키워드
 
         query = Q()
-        
+
         # hashtag
-        hashtag_instance = Hashtag.objects.get(tag__exact=hashtag)
-        queryset = hashtag_instance.tagging.all()
+        try:
+            hashtag_instance = Hashtag.objects.get(tag__exact=hashtag)
+            queryset = hashtag_instance.tagging.all()
+
+        except Hashtag.DoesNotExist:
+            raise NotFound("해당 태그가 포함된 게시물을 찾을 수 없습니다.")
 
         # type
         if type: query |= Q(feed_type=type)


### PR DESCRIPTION
## 반영 브랜치
kyeon -> develop

## 변경 사항
### 1. 게시글 목록 조회 시 정확한 hashtag가 없는 경우 DoesNotExist 예외 발생
![image](https://github.com/wanted-A/Team-A/assets/111492415/55df2035-beaf-42a1-84d6-7f42c7c9f8a4)
```python
# 변경 코드
# hashtag
try:
    hashtag_instance = Hashtag.objects.get(tag__exact=hashtag)
    queryset = hashtag_instance.tagging.all()

except Hashtag.DoesNotExist:
    raise NotFound("해당 태그가 포함된 게시물을 찾을 수 없습니다.")
```

### 2. 게시글 작성 시 content가 없을 경우 TypeError 발생
![image](https://github.com/wanted-A/Team-A/assets/111492415/52223803-9cd2-4fac-a121-96b2d1a75907)
```python
# 아래와 같이 조건문 추가
def to_representation(self, instance):
    # content 최대 20자 까지만 표현
    res = super().to_representation(instance)
    if res and len(res["content"]) > 20:
        res.update({'content': res['content'][:20]})
    return res
```

### 3. Board Model hashtags 제약조건 추가(blank=True)
- `hashtag`는 선택사항이기 때문에  `blank=True` 조건을 추가하였다.
- `null=True`는 `ManyToManyField`의 기본 조건이기 떄문에 작성하지 않았다.

## 테스트 결과
### content 내용이 없어도 조회가 되는 것을 확인할 수 있다.
![image](https://github.com/wanted-A/Team-A/assets/111492415/6b97c1d8-3a4d-4c59-8982-0a3d9c7360cf)
### hashtag에 대한 query가 없을 경우
![image](https://github.com/wanted-A/Team-A/assets/111492415/b031c2d0-64ed-4f55-a3a6-523cbfad9b91)

