### PR TITLE
[오류 수정] hashtag를 여러번 생성할 경우 post되지 않는 오류 수정

### DIFF
--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -4,11 +4,12 @@ from .models import Board, Hashtag
 
 class BoardSerializer(serializers.ModelSerializer):
     owner = serializers.StringRelatedField(read_only=True)
-    hashtags = serializers.SlugRelatedField(
-        many=True,
-        queryset=Hashtag.objects.all(),
-        slug_field="tag",
-    )
+    hashtags = serializers.StringRelatedField(many=True, read_only=True)
+    # hashtags = serializers.SlugRelatedField(
+    #     many=True,
+    #     queryset=Hashtag.objects.all(),
+    #     slug_field="tag",
+    # )
 
     class Meta:
         model = Board

--- a/boards/views.py
+++ b/boards/views.py
@@ -35,25 +35,20 @@ class BoardWriteView(APIView):
             status=status.HTTP_200_OK,
         )
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request):
         serializer = BoardSerializer(data=request.data)
 
         if serializer.is_valid():
-            board = serializer.save(owner=self.request.user)
-
             hashtags_data = request.data.get("hashtags", [])
-
             hashtags_objs = []
 
             for hashtag in hashtags_data:
-                hashtag = hashtag.strip()
-                hashtag_obj, created = Hashtag.objects.get_or_create(tag=hashtag)
-                hashtags_objs.append(hashtag_obj)
+                hashtag, created = Hashtag.objects.get_or_create(tag=hashtag.strip())
+                hashtags_objs.append(hashtag)
 
+            board = serializer.save(owner=request.user)
             board.hashtags.set(hashtags_objs)
             board.save()
-
-            # serializer.save(owner=request.user, hashtags=hashtags_objs)
 
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         else:
@@ -67,6 +62,7 @@ class BoardListAPIView(APIView):
 
     게시글 목록 조회 및 검색 기능
     """
+
     permission_classes = [permissions.AllowAny]
 
     query_hashtag = openapi.Parameter(


### PR DESCRIPTION
## 반영 브랜치
suhyun -> develop

---

## 변경 된 코드
```py
def post(self, request):
        serializer = BoardSerializer(data=request.data)

        if serializer.is_valid():
            hashtags_data = request.data.get("hashtags", [])
            hashtags_objs = []

            for hashtag in hashtags_data:
                hashtag, created = Hashtag.objects.get_or_create(tag=hashtag.strip())
                hashtags_objs.append(hashtag)

            board = serializer.save(owner=request.user) # 위치 수정
            board.hashtags.set(hashtags_objs)
            board.save()

            return Response(serializer.data, status=status.HTTP_201_CREATED)
        else:
            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
```
```py
class BoardSerializer(serializers.ModelSerializer):
    owner = serializers.StringRelatedField(read_only=True)
    hashtags = serializers.StringRelatedField(many=True, read_only=True) # 수정
```
---

## 테스트 결과
```py
{
    "content_id": 12,
    "owner": "admin",
    "title": "제목",
    "feed_type": "twitter",
    "content": null,
    "hashtags": [
        "수박",
        "딸기"
    ],
    "viewcounts": 0,
    "likecounts": 0,
    "sharecounts": 0,
    "created_at": "2023-10-30T20:57:29.563828",
    "updated_at": "2023-10-30T20:57:29.578679"
}
```
데이터베이스에 없는 해시태그를 여러번 작성해도 오류 없이 post 됩니다.
해시태그는 데이터베이스에 저장됩니다.