### PR TITLE
[기능 추가] email 인증 추가

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -187,12 +187,18 @@ SWAGGER_SETTINGS = {
     }
 }
 
-# 이메일 발송 로직 (가칭)
-# EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-# EMAIL_HOST = "smtp.gmail.com"  # Gmail SMTP 호스트 설정
-# EMAIL_PORT = 587  # SMTP 포트 설정
-# EMAIL_USE_TLS = True  # TLS 사용 여부 설정
-# EMAIL_USE_SSL = False  # SSL 사용 여부 설정
-# EMAIL_HOST_USER = "emailtjfakdlTrpTskdlrp@gmail.com"  # Gmail 이메일 계정
-# EMAIL_HOST_PASSWORD = "testpasswordtjfakdlTrpTsk"  # Gmail 계정 비밀번호
-# DEFAULT_FROM_EMAIL = "emailtjfakdlTrpTskdlrp@gmail.com"  # 기본 발신 이메일 주소
+## 이메일 인증 시작 ##
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"  # 메일을 보내는 방식
+EMAIL_HOST = env("EMAIL_HOST")  # 메일을 호스트 하는 서버
+EMAIL_PORT = 587  # 메일과 통신하는 포트
+EMAIL_USE_TLS = True  # TLS 보안 사용
+EMAIL_HOST_USER = env("EMAIL_HOST_USER")  # 발신할 네이버 이메일
+EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")  # 네이버 앱 비밀번호
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER  # 사이트와 관련한 자동 응답 받을 이메일 주소
+
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"  # 이메일 인증을 필수로 설정
+ACCOUNT_EMAIL_ON_GET = True  # 이메일 인증시 이메일을 보내줌
+ACCOUNT_EMAIL_SUBJECT_PREFIX = "[회원가입 이메일 인증] "  # 이메일에 자동으로 표시되는 제목
+ACCOUNT_CONFIRM_EMAIL_ON_GET = True  # 유저가 받은 링크를 클릭하면 회원가입 완료
+
+ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 5  # 로그인 실패 횟수 제한

--- a/users/admin.py
+++ b/users/admin.py
@@ -18,5 +18,5 @@ class UserAdmin(admin.ModelAdmin):
             },
         ),
     )
-    list_display = ("id", "username", "email")
+    list_display = ("id", "username", "email", "is_approved", "is_active")
     list_display_links = ("id", "username", "email")

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -36,8 +36,6 @@ class UserSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("비밀번호는 최소 한 개의 숫자를 포함해야 합니다.")
         if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", value):
             raise serializers.ValidationError("비밀번호는 최소 한 개의 특수문자를 포함해야 합니다.")
-        if re.search(r"1\d{3}", value):
-            raise serializers.ValidationError("비밀번호에 연속된 숫자를 사용할 수 없습니다.")
         if re.search(r"(.)\1\1", value):
             raise serializers.ValidationError("비밀번호에 같은 문자를 3번 이상 사용할 수 없습니다.")
 

--- a/users/urls.py
+++ b/users/urls.py
@@ -8,11 +8,14 @@
 # ]
 
 from django.urls import path
-from .views import ResgisterView, LogoutView ,LoginView
+from .views import ResgisterView, LogoutView ,LoginView, VerifyEmail
+from rest_framework_simplejwt.views import TokenVerifyView
 
 urlpatterns = [
     path("register/", ResgisterView.as_view(), name="register"),
     path("login/", LoginView.as_view(), name="login"),
     path("logout/", LogoutView.as_view(), name="logout"),
     # path("change-password/", ChangePasswordView.as_view(), name="change_password"),
+    path("token/verify/", TokenVerifyView.as_view(), name="token_verify"),
+    path("verify/<str:token>",VerifyEmail.as_view()),
 ]


### PR DESCRIPTION
## 반영 브랜치
suhyun -> develop

---

## 추가 된 기능 / 테스트 결과
http://127.0.0.1:8000/api/v1/users/register/
```py
{
"username":"이메일 인증",
"email":"id_suhyun@naver.com",
"password":"Qpqp1010~!"
}
```
![image](https://github.com/wanted-A/Total-Feed-Service/assets/101565486/e8d1fe4b-1725-4abc-8c8b-8d459d8caffa)

이메일 인증 링크 클릭 전
![image](https://github.com/wanted-A/Total-Feed-Service/assets/101565486/1c95bb8e-3004-4008-9153-f89e8773ff00)

이메일 인증 링크 클릭 후
![image](https://github.com/wanted-A/Total-Feed-Service/assets/101565486/4d117a2a-9e28-4294-92d6-479a576fae5a)

---

### 추가 개발 필요 부분
`is_approve = False` 일 경우, 이메일 인증을 먼저 완료하라는 오류를 띄워야 합니다.